### PR TITLE
Add XML DropManager editor with model support

### DIFF
--- a/MU.ToolKit [Silver Edition]/MU.ToolKit [Silver Edition].csproj
+++ b/MU.ToolKit [Silver Edition]/MU.ToolKit [Silver Edition].csproj
@@ -100,6 +100,12 @@
     <Compile Include="MU_ToolKit\Form_DropManager.Designer.cs">
       <DependentUpon>Form_DropManager.cs</DependentUpon>
     </Compile>
+    <Compile Include="MU_ToolKit\Form_DropManager_XML.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="MU_ToolKit\Form_DropManager_XML.Designer.cs">
+      <DependentUpon>Form_DropManager_XML.cs</DependentUpon>
+    </Compile>
     <Compile Include="MU_ToolKit\Form_Search.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -174,6 +180,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="MU_ToolKit\Form_DropManager.resx">
       <DependentUpon>Form_DropManager.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="MU_ToolKit\Form_DropManager_XML.resx">
+      <DependentUpon>Form_DropManager_XML.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="MU_ToolKit\Form_Search.resx">
       <DependentUpon>Form_Search.cs</DependentUpon>

--- a/MU.ToolKit [Silver Edition]/MU_ToolKit/Form1.Designer.cs
+++ b/MU.ToolKit [Silver Edition]/MU_ToolKit/Form1.Designer.cs
@@ -64,6 +64,8 @@
 			this.xMLNewToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
 			this.cashShopToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
 			this.iGCDropManagerEditorToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
+			this.dropManagerTextToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
+			this.dropManagerXmlToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
 			this.configToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
 			this.itemListSettingsTypeToolStripMenuItem = new global::System.Windows.Forms.ToolStripMenuItem();
 			this.ex700ItemList_ToolStripMenuItem_ON = new global::System.Windows.Forms.ToolStripMenuItem();

--- a/MU.ToolKit [Silver Edition]/MU_ToolKit/Form1.Designer.cs
+++ b/MU.ToolKit [Silver Edition]/MU_ToolKit/Form1.Designer.cs
@@ -303,14 +303,14 @@
 			this.computeIGCCRCToolStripMenuItem.Size = new global::System.Drawing.Size(236, 22);
 			this.computeIGCCRCToolStripMenuItem.Text = "Compute MU CRC";
 			this.computeIGCCRCToolStripMenuItem.Click += new global::System.EventHandler(this.computeIGCCRCToolStripMenuItem_Click);
-			this.serverToolStripMenuItem.DropDownItems.AddRange(new global::System.Windows.Forms.ToolStripItem[]
-			{
-				this.monsterSetBaseToolStripMenuItem,
-				this.shopToolStripMenuItem,
-				this.eventBagToolStripMenuItem,
-				this.cashShopToolStripMenuItem,
-				this.iGCDropManagerEditorToolStripMenuItem
-			});
+                        this.serverToolStripMenuItem.DropDownItems.AddRange(new global::System.Windows.Forms.ToolStripItem[]
+                        {
+                                this.monsterSetBaseToolStripMenuItem,
+                                this.shopToolStripMenuItem,
+                                this.eventBagToolStripMenuItem,
+                                this.cashShopToolStripMenuItem,
+                                this.iGCDropManagerEditorToolStripMenuItem
+                        });
 			this.serverToolStripMenuItem.Name = "serverToolStripMenuItem";
 			this.serverToolStripMenuItem.Size = new global::System.Drawing.Size(93, 21);
 			this.serverToolStripMenuItem.Text = "Server Tools";
@@ -342,10 +342,22 @@
 			this.cashShopToolStripMenuItem.Size = new global::System.Drawing.Size(266, 22);
 			this.cashShopToolStripMenuItem.Text = "CashShop Editor";
 			this.cashShopToolStripMenuItem.Click += new global::System.EventHandler(this.cSToolStripMenuItem_Click);
-			this.iGCDropManagerEditorToolStripMenuItem.Name = "iGCDropManagerEditorToolStripMenuItem";
-			this.iGCDropManagerEditorToolStripMenuItem.Size = new global::System.Drawing.Size(266, 22);
-			this.iGCDropManagerEditorToolStripMenuItem.Text = "MU DropManager Editor";
-			this.iGCDropManagerEditorToolStripMenuItem.Click += new global::System.EventHandler(this.iGCDropManagerEditorToolStripMenuItem_Click);
+                        this.iGCDropManagerEditorToolStripMenuItem.DropDownItems.AddRange(new global::System.Windows.Forms.ToolStripItem[]
+                        {
+                                this.dropManagerTextToolStripMenuItem,
+                                this.dropManagerXmlToolStripMenuItem
+                        });
+                        this.iGCDropManagerEditorToolStripMenuItem.Name = "iGCDropManagerEditorToolStripMenuItem";
+                        this.iGCDropManagerEditorToolStripMenuItem.Size = new global::System.Drawing.Size(266, 22);
+                        this.iGCDropManagerEditorToolStripMenuItem.Text = "MU DropManager Editor";
+                        this.dropManagerTextToolStripMenuItem.Name = "dropManagerTextToolStripMenuItem";
+                        this.dropManagerTextToolStripMenuItem.Size = new global::System.Drawing.Size(139, 22);
+                        this.dropManagerTextToolStripMenuItem.Text = "Text (Old)";
+                        this.dropManagerTextToolStripMenuItem.Click += new global::System.EventHandler(this.iGCDropManagerEditorToolStripMenuItem_Click);
+                        this.dropManagerXmlToolStripMenuItem.Name = "dropManagerXmlToolStripMenuItem";
+                        this.dropManagerXmlToolStripMenuItem.Size = new global::System.Drawing.Size(139, 22);
+                        this.dropManagerXmlToolStripMenuItem.Text = "XML (New)";
+                        this.dropManagerXmlToolStripMenuItem.Click += new global::System.EventHandler(this.iGCDropManagerXmlToolStripMenuItem_Click);
 			this.configToolStripMenuItem.DropDownItems.AddRange(new global::System.Windows.Forms.ToolStripItem[]
 			{
 				this.itemListSettingsTypeToolStripMenuItem
@@ -610,10 +622,16 @@
 		private global::System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
 
 		// Token: 0x040002D0 RID: 720
-		private global::System.Windows.Forms.ToolStripMenuItem iGCDropManagerEditorToolStripMenuItem;
+                private global::System.Windows.Forms.ToolStripMenuItem iGCDropManagerEditorToolStripMenuItem;
 
-		// Token: 0x040002D6 RID: 726
-		private global::System.Windows.Forms.ToolStripMenuItem itemAddOptionbmdToolStripMenuItem;
+                // Token: 0x040002D1 RID: 721
+                private global::System.Windows.Forms.ToolStripMenuItem dropManagerTextToolStripMenuItem;
+
+                // Token: 0x040002D2 RID: 722
+                private global::System.Windows.Forms.ToolStripMenuItem dropManagerXmlToolStripMenuItem;
+
+                // Token: 0x040002D6 RID: 726
+                private global::System.Windows.Forms.ToolStripMenuItem itemAddOptionbmdToolStripMenuItem;
 
 		// Token: 0x040002D7 RID: 727
 		private global::System.Windows.Forms.ToolStripMenuItem ItemEx700PlusToolStripMenuItem_Load;

--- a/MU.ToolKit [Silver Edition]/MU_ToolKit/Form1.cs
+++ b/MU.ToolKit [Silver Edition]/MU_ToolKit/Form1.cs
@@ -1834,10 +1834,15 @@ namespace MU_ToolKit
 		}
 
 		// Token: 0x060004E0 RID: 1248 RVA: 0x00026C87 File Offset: 0x00024E87
-		private void iGCDropManagerEditorToolStripMenuItem_Click(object sender, EventArgs e)
-		{
-			new Form_DropManager().Show();
-		}
+                private void iGCDropManagerEditorToolStripMenuItem_Click(object sender, EventArgs e)
+                {
+                        new Form_DropManager().Show();
+                }
+
+                private void iGCDropManagerXmlToolStripMenuItem_Click(object sender, EventArgs e)
+                {
+                        new Form_DropManager_XML().Show();
+                }
 
 		// Token: 0x060004E2 RID: 1250 RVA: 0x00028CC4 File Offset: 0x00026EC4
 		private void initializeFilterGrid(DataGridView dgv)

--- a/MU.ToolKit [Silver Edition]/MU_ToolKit/Form_DropManager_XML.Designer.cs
+++ b/MU.ToolKit [Silver Edition]/MU_ToolKit/Form_DropManager_XML.Designer.cs
@@ -1,0 +1,600 @@
+namespace MU_ToolKit
+{
+    partial class Form_DropManager_XML
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.newToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.splitContainerMain = new System.Windows.Forms.SplitContainer();
+            this.tableLayoutPanelMonsters = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanelDropUseRate = new System.Windows.Forms.FlowLayoutPanel();
+            this.labelDropUseRate = new System.Windows.Forms.Label();
+            this.textBoxDropUseRate = new System.Windows.Forms.TextBox();
+            this.dataGridViewMonsters = new System.Windows.Forms.DataGridView();
+            this.columnMonsterIndex = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnMonsterMinLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnMonsterMaxLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnMonsterMapNumber = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnMonsterItemRate = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnMonsterItemCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnMonsterCoinReward = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnMonsterCoinType = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnMonsterCoinValue = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnMonsterPlayerMinLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnMonsterPlayerMaxLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.flowLayoutPanelMonsterButtons = new System.Windows.Forms.FlowLayoutPanel();
+            this.buttonAddMonster = new System.Windows.Forms.Button();
+            this.buttonRemoveMonster = new System.Windows.Forms.Button();
+            this.tableLayoutPanelItems = new System.Windows.Forms.TableLayoutPanel();
+            this.dataGridViewItems = new System.Windows.Forms.DataGridView();
+            this.columnItemCat = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemIndex = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemMinLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemMaxLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemDurability = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemSkill = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemLuck = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemOption = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemExc = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemSetItem = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemSocketCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemElementalItem = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemMuunCat = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemMuunIndex = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemDropRate = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnItemDuration = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.flowLayoutPanelItemButtons = new System.Windows.Forms.FlowLayoutPanel();
+            this.buttonAddItem = new System.Windows.Forms.Button();
+            this.buttonRemoveItem = new System.Windows.Forms.Button();
+            this.menuStrip1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).BeginInit();
+            this.splitContainerMain.Panel1.SuspendLayout();
+            this.splitContainerMain.Panel2.SuspendLayout();
+            this.splitContainerMain.SuspendLayout();
+            this.tableLayoutPanelMonsters.SuspendLayout();
+            this.flowLayoutPanelDropUseRate.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewMonsters)).BeginInit();
+            this.flowLayoutPanelMonsterButtons.SuspendLayout();
+            this.tableLayoutPanelItems.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewItems)).BeginInit();
+            this.flowLayoutPanelItemButtons.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // menuStrip1
+            // 
+            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.fileToolStripMenuItem});
+            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
+            this.menuStrip1.Name = "menuStrip1";
+            this.menuStrip1.Size = new System.Drawing.Size(984, 24);
+            this.menuStrip1.TabIndex = 0;
+            this.menuStrip1.Text = "menuStrip1";
+            // 
+            // fileToolStripMenuItem
+            // 
+            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.newToolStripMenuItem,
+            this.openToolStripMenuItem,
+            this.saveToolStripMenuItem,
+            this.saveAsToolStripMenuItem});
+            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Text = "File";
+            // 
+            // newToolStripMenuItem
+            // 
+            this.newToolStripMenuItem.Name = "newToolStripMenuItem";
+            this.newToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
+            this.newToolStripMenuItem.Text = "New";
+            this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);
+            // 
+            // openToolStripMenuItem
+            // 
+            this.openToolStripMenuItem.Name = "openToolStripMenuItem";
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
+            this.openToolStripMenuItem.Text = "Open...";
+            this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
+            // 
+            // saveToolStripMenuItem
+            // 
+            this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
+            this.saveToolStripMenuItem.Text = "Save";
+            this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
+            // 
+            // saveAsToolStripMenuItem
+            // 
+            this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
+            this.saveAsToolStripMenuItem.Text = "Save As...";
+            this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
+            // 
+            // splitContainerMain
+            // 
+            this.splitContainerMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainerMain.Location = new System.Drawing.Point(0, 24);
+            this.splitContainerMain.Name = "splitContainerMain";
+            this.splitContainerMain.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainerMain.Panel1
+            // 
+            this.splitContainerMain.Panel1.Controls.Add(this.tableLayoutPanelMonsters);
+            // 
+            // splitContainerMain.Panel2
+            // 
+            this.splitContainerMain.Panel2.Controls.Add(this.tableLayoutPanelItems);
+            this.splitContainerMain.Size = new System.Drawing.Size(984, 637);
+            this.splitContainerMain.SplitterDistance = 292;
+            this.splitContainerMain.TabIndex = 1;
+            // 
+            // tableLayoutPanelMonsters
+            // 
+            this.tableLayoutPanelMonsters.ColumnCount = 1;
+            this.tableLayoutPanelMonsters.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelMonsters.Controls.Add(this.flowLayoutPanelDropUseRate, 0, 0);
+            this.tableLayoutPanelMonsters.Controls.Add(this.dataGridViewMonsters, 0, 1);
+            this.tableLayoutPanelMonsters.Controls.Add(this.flowLayoutPanelMonsterButtons, 0, 2);
+            this.tableLayoutPanelMonsters.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanelMonsters.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanelMonsters.Name = "tableLayoutPanelMonsters";
+            this.tableLayoutPanelMonsters.RowCount = 3;
+            this.tableLayoutPanelMonsters.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelMonsters.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelMonsters.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelMonsters.Size = new System.Drawing.Size(984, 292);
+            this.tableLayoutPanelMonsters.TabIndex = 0;
+            // 
+            // flowLayoutPanelDropUseRate
+            // 
+            this.flowLayoutPanelDropUseRate.AutoSize = true;
+            this.flowLayoutPanelDropUseRate.Controls.Add(this.labelDropUseRate);
+            this.flowLayoutPanelDropUseRate.Controls.Add(this.textBoxDropUseRate);
+            this.flowLayoutPanelDropUseRate.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanelDropUseRate.Location = new System.Drawing.Point(3, 3);
+            this.flowLayoutPanelDropUseRate.Name = "flowLayoutPanelDropUseRate";
+            this.flowLayoutPanelDropUseRate.Size = new System.Drawing.Size(978, 26);
+            this.flowLayoutPanelDropUseRate.TabIndex = 0;
+            // 
+            // labelDropUseRate
+            // 
+            this.labelDropUseRate.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.labelDropUseRate.AutoSize = true;
+            this.labelDropUseRate.Location = new System.Drawing.Point(3, 6);
+            this.labelDropUseRate.Name = "labelDropUseRate";
+            this.labelDropUseRate.Size = new System.Drawing.Size(78, 13);
+            this.labelDropUseRate.TabIndex = 0;
+            this.labelDropUseRate.Text = "DropUseRate:";
+            // 
+            // textBoxDropUseRate
+            // 
+            this.textBoxDropUseRate.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.textBoxDropUseRate.Location = new System.Drawing.Point(87, 3);
+            this.textBoxDropUseRate.Name = "textBoxDropUseRate";
+            this.textBoxDropUseRate.Size = new System.Drawing.Size(120, 20);
+            this.textBoxDropUseRate.TabIndex = 1;
+            this.textBoxDropUseRate.TextChanged += new System.EventHandler(this.textBoxDropUseRate_TextChanged);
+            // 
+            // dataGridViewMonsters
+            // 
+            this.dataGridViewMonsters.AllowUserToAddRows = false;
+            this.dataGridViewMonsters.AllowUserToDeleteRows = false;
+            this.dataGridViewMonsters.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dataGridViewMonsters.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewMonsters.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.columnMonsterIndex,
+            this.columnMonsterMinLevel,
+            this.columnMonsterMaxLevel,
+            this.columnMonsterMapNumber,
+            this.columnMonsterItemRate,
+            this.columnMonsterItemCount,
+            this.columnMonsterCoinReward,
+            this.columnMonsterCoinType,
+            this.columnMonsterCoinValue,
+            this.columnMonsterPlayerMinLevel,
+            this.columnMonsterPlayerMaxLevel});
+            this.dataGridViewMonsters.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.dataGridViewMonsters.Location = new System.Drawing.Point(3, 35);
+            this.dataGridViewMonsters.MultiSelect = false;
+            this.dataGridViewMonsters.Name = "dataGridViewMonsters";
+            this.dataGridViewMonsters.RowHeadersVisible = false;
+            this.dataGridViewMonsters.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.dataGridViewMonsters.Size = new System.Drawing.Size(978, 221);
+            this.dataGridViewMonsters.TabIndex = 1;
+            this.dataGridViewMonsters.SelectionChanged += new System.EventHandler(this.dataGridViewMonsters_SelectionChanged);
+            // 
+            // columnMonsterIndex
+            // 
+            this.columnMonsterIndex.DataPropertyName = "Index";
+            this.columnMonsterIndex.HeaderText = "Index";
+            this.columnMonsterIndex.Name = "columnMonsterIndex";
+            // 
+            // columnMonsterMinLevel
+            // 
+            this.columnMonsterMinLevel.DataPropertyName = "MonsterMinLevel";
+            this.columnMonsterMinLevel.HeaderText = "Monster Min Level";
+            this.columnMonsterMinLevel.Name = "columnMonsterMinLevel";
+            // 
+            // columnMonsterMaxLevel
+            // 
+            this.columnMonsterMaxLevel.DataPropertyName = "MonsterMaxLevel";
+            this.columnMonsterMaxLevel.HeaderText = "Monster Max Level";
+            this.columnMonsterMaxLevel.Name = "columnMonsterMaxLevel";
+            // 
+            // columnMonsterMapNumber
+            // 
+            this.columnMonsterMapNumber.DataPropertyName = "MapNumber";
+            this.columnMonsterMapNumber.HeaderText = "Map";
+            this.columnMonsterMapNumber.Name = "columnMonsterMapNumber";
+            // 
+            // columnMonsterItemRate
+            // 
+            this.columnMonsterItemRate.DataPropertyName = "ItemRate";
+            this.columnMonsterItemRate.HeaderText = "Item Rate";
+            this.columnMonsterItemRate.Name = "columnMonsterItemRate";
+            // 
+            // columnMonsterItemCount
+            // 
+            this.columnMonsterItemCount.DataPropertyName = "ItemCount";
+            this.columnMonsterItemCount.HeaderText = "Item Count";
+            this.columnMonsterItemCount.Name = "columnMonsterItemCount";
+            // 
+            // columnMonsterCoinReward
+            // 
+            this.columnMonsterCoinReward.DataPropertyName = "CoinReward";
+            this.columnMonsterCoinReward.HeaderText = "Coin Reward";
+            this.columnMonsterCoinReward.Name = "columnMonsterCoinReward";
+            // 
+            // columnMonsterCoinType
+            // 
+            this.columnMonsterCoinType.DataPropertyName = "CoinType";
+            this.columnMonsterCoinType.HeaderText = "Coin Type";
+            this.columnMonsterCoinType.Name = "columnMonsterCoinType";
+            // 
+            // columnMonsterCoinValue
+            // 
+            this.columnMonsterCoinValue.DataPropertyName = "CoinValue";
+            this.columnMonsterCoinValue.HeaderText = "Coin Value";
+            this.columnMonsterCoinValue.Name = "columnMonsterCoinValue";
+            // 
+            // columnMonsterPlayerMinLevel
+            // 
+            this.columnMonsterPlayerMinLevel.DataPropertyName = "PlayerMinLevel";
+            this.columnMonsterPlayerMinLevel.HeaderText = "Player Min Level";
+            this.columnMonsterPlayerMinLevel.Name = "columnMonsterPlayerMinLevel";
+            // 
+            // columnMonsterPlayerMaxLevel
+            // 
+            this.columnMonsterPlayerMaxLevel.DataPropertyName = "PlayerMaxLevel";
+            this.columnMonsterPlayerMaxLevel.HeaderText = "Player Max Level";
+            this.columnMonsterPlayerMaxLevel.Name = "columnMonsterPlayerMaxLevel";
+            // 
+            // flowLayoutPanelMonsterButtons
+            // 
+            this.flowLayoutPanelMonsterButtons.AutoSize = true;
+            this.flowLayoutPanelMonsterButtons.Controls.Add(this.buttonAddMonster);
+            this.flowLayoutPanelMonsterButtons.Controls.Add(this.buttonRemoveMonster);
+            this.flowLayoutPanelMonsterButtons.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanelMonsterButtons.FlowDirection = System.Windows.Forms.FlowDirection.LeftToRight;
+            this.flowLayoutPanelMonsterButtons.Location = new System.Drawing.Point(3, 262);
+            this.flowLayoutPanelMonsterButtons.Name = "flowLayoutPanelMonsterButtons";
+            this.flowLayoutPanelMonsterButtons.Size = new System.Drawing.Size(978, 27);
+            this.flowLayoutPanelMonsterButtons.TabIndex = 2;
+            this.flowLayoutPanelMonsterButtons.WrapContents = false;
+            // 
+            // buttonAddMonster
+            // 
+            this.buttonAddMonster.AutoSize = true;
+            this.buttonAddMonster.Location = new System.Drawing.Point(3, 3);
+            this.buttonAddMonster.Name = "buttonAddMonster";
+            this.buttonAddMonster.Size = new System.Drawing.Size(88, 23);
+            this.buttonAddMonster.TabIndex = 0;
+            this.buttonAddMonster.Text = "Add Monster";
+            this.buttonAddMonster.UseVisualStyleBackColor = true;
+            this.buttonAddMonster.Click += new System.EventHandler(this.buttonAddMonster_Click);
+            // 
+            // buttonRemoveMonster
+            // 
+            this.buttonRemoveMonster.AutoSize = true;
+            this.buttonRemoveMonster.Location = new System.Drawing.Point(97, 3);
+            this.buttonRemoveMonster.Name = "buttonRemoveMonster";
+            this.buttonRemoveMonster.Size = new System.Drawing.Size(106, 23);
+            this.buttonRemoveMonster.TabIndex = 1;
+            this.buttonRemoveMonster.Text = "Remove Monster";
+            this.buttonRemoveMonster.UseVisualStyleBackColor = true;
+            this.buttonRemoveMonster.Click += new System.EventHandler(this.buttonRemoveMonster_Click);
+            // 
+            // tableLayoutPanelItems
+            // 
+            this.tableLayoutPanelItems.ColumnCount = 1;
+            this.tableLayoutPanelItems.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelItems.Controls.Add(this.dataGridViewItems, 0, 0);
+            this.tableLayoutPanelItems.Controls.Add(this.flowLayoutPanelItemButtons, 0, 1);
+            this.tableLayoutPanelItems.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanelItems.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanelItems.Name = "tableLayoutPanelItems";
+            this.tableLayoutPanelItems.RowCount = 2;
+            this.tableLayoutPanelItems.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanelItems.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelItems.Size = new System.Drawing.Size(984, 341);
+            this.tableLayoutPanelItems.TabIndex = 0;
+            // 
+            // dataGridViewItems
+            // 
+            this.dataGridViewItems.AllowUserToAddRows = false;
+            this.dataGridViewItems.AllowUserToDeleteRows = false;
+            this.dataGridViewItems.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.dataGridViewItems.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewItems.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.columnItemCat,
+            this.columnItemIndex,
+            this.columnItemMinLevel,
+            this.columnItemMaxLevel,
+            this.columnItemDurability,
+            this.columnItemSkill,
+            this.columnItemLuck,
+            this.columnItemOption,
+            this.columnItemExc,
+            this.columnItemSetItem,
+            this.columnItemSocketCount,
+            this.columnItemElementalItem,
+            this.columnItemMuunCat,
+            this.columnItemMuunIndex,
+            this.columnItemDropRate,
+            this.columnItemDuration});
+            this.dataGridViewItems.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.dataGridViewItems.Location = new System.Drawing.Point(3, 3);
+            this.dataGridViewItems.MultiSelect = false;
+            this.dataGridViewItems.Name = "dataGridViewItems";
+            this.dataGridViewItems.RowHeadersVisible = false;
+            this.dataGridViewItems.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.dataGridViewItems.Size = new System.Drawing.Size(978, 303);
+            this.dataGridViewItems.TabIndex = 0;
+            // 
+            // columnItemCat
+            // 
+            this.columnItemCat.DataPropertyName = "Cat";
+            this.columnItemCat.HeaderText = "Cat";
+            this.columnItemCat.Name = "columnItemCat";
+            // 
+            // columnItemIndex
+            // 
+            this.columnItemIndex.DataPropertyName = "Index";
+            this.columnItemIndex.HeaderText = "Index";
+            this.columnItemIndex.Name = "columnItemIndex";
+            // 
+            // columnItemMinLevel
+            // 
+            this.columnItemMinLevel.DataPropertyName = "ItemMinLevel";
+            this.columnItemMinLevel.HeaderText = "Item Min Level";
+            this.columnItemMinLevel.Name = "columnItemMinLevel";
+            // 
+            // columnItemMaxLevel
+            // 
+            this.columnItemMaxLevel.DataPropertyName = "ItemMaxLevel";
+            this.columnItemMaxLevel.HeaderText = "Item Max Level";
+            this.columnItemMaxLevel.Name = "columnItemMaxLevel";
+            // 
+            // columnItemDurability
+            // 
+            this.columnItemDurability.DataPropertyName = "Durability";
+            this.columnItemDurability.HeaderText = "Durability";
+            this.columnItemDurability.Name = "columnItemDurability";
+            // 
+            // columnItemSkill
+            // 
+            this.columnItemSkill.DataPropertyName = "Skill";
+            this.columnItemSkill.HeaderText = "Skill";
+            this.columnItemSkill.Name = "columnItemSkill";
+            // 
+            // columnItemLuck
+            // 
+            this.columnItemLuck.DataPropertyName = "Luck";
+            this.columnItemLuck.HeaderText = "Luck";
+            this.columnItemLuck.Name = "columnItemLuck";
+            // 
+            // columnItemOption
+            // 
+            this.columnItemOption.DataPropertyName = "Option";
+            this.columnItemOption.HeaderText = "Option";
+            this.columnItemOption.Name = "columnItemOption";
+            // 
+            // columnItemExc
+            // 
+            this.columnItemExc.DataPropertyName = "Exc";
+            this.columnItemExc.HeaderText = "Exc";
+            this.columnItemExc.Name = "columnItemExc";
+            // 
+            // columnItemSetItem
+            // 
+            this.columnItemSetItem.DataPropertyName = "SetItem";
+            this.columnItemSetItem.HeaderText = "Set Item";
+            this.columnItemSetItem.Name = "columnItemSetItem";
+            // 
+            // columnItemSocketCount
+            // 
+            this.columnItemSocketCount.DataPropertyName = "SocketCount";
+            this.columnItemSocketCount.HeaderText = "Socket Count";
+            this.columnItemSocketCount.Name = "columnItemSocketCount";
+            // 
+            // columnItemElementalItem
+            // 
+            this.columnItemElementalItem.DataPropertyName = "ElementalItem";
+            this.columnItemElementalItem.HeaderText = "Elemental";
+            this.columnItemElementalItem.Name = "columnItemElementalItem";
+            // 
+            // columnItemMuunCat
+            // 
+            this.columnItemMuunCat.DataPropertyName = "MuunEvolutionItemCat";
+            this.columnItemMuunCat.HeaderText = "Muun Cat";
+            this.columnItemMuunCat.Name = "columnItemMuunCat";
+            // 
+            // columnItemMuunIndex
+            // 
+            this.columnItemMuunIndex.DataPropertyName = "MuunEvolutionItemIndex";
+            this.columnItemMuunIndex.HeaderText = "Muun Index";
+            this.columnItemMuunIndex.Name = "columnItemMuunIndex";
+            // 
+            // columnItemDropRate
+            // 
+            this.columnItemDropRate.DataPropertyName = "DropRate";
+            this.columnItemDropRate.HeaderText = "Drop Rate";
+            this.columnItemDropRate.Name = "columnItemDropRate";
+            // 
+            // columnItemDuration
+            // 
+            this.columnItemDuration.DataPropertyName = "Duration";
+            this.columnItemDuration.HeaderText = "Duration";
+            this.columnItemDuration.Name = "columnItemDuration";
+            // 
+            // flowLayoutPanelItemButtons
+            // 
+            this.flowLayoutPanelItemButtons.AutoSize = true;
+            this.flowLayoutPanelItemButtons.Controls.Add(this.buttonAddItem);
+            this.flowLayoutPanelItemButtons.Controls.Add(this.buttonRemoveItem);
+            this.flowLayoutPanelItemButtons.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanelItemButtons.FlowDirection = System.Windows.Forms.FlowDirection.LeftToRight;
+            this.flowLayoutPanelItemButtons.Location = new System.Drawing.Point(3, 312);
+            this.flowLayoutPanelItemButtons.Name = "flowLayoutPanelItemButtons";
+            this.flowLayoutPanelItemButtons.Size = new System.Drawing.Size(978, 26);
+            this.flowLayoutPanelItemButtons.TabIndex = 1;
+            this.flowLayoutPanelItemButtons.WrapContents = false;
+            // 
+            // buttonAddItem
+            // 
+            this.buttonAddItem.AutoSize = true;
+            this.buttonAddItem.Location = new System.Drawing.Point(3, 3);
+            this.buttonAddItem.Name = "buttonAddItem";
+            this.buttonAddItem.Size = new System.Drawing.Size(63, 23);
+            this.buttonAddItem.TabIndex = 0;
+            this.buttonAddItem.Text = "Add Item";
+            this.buttonAddItem.UseVisualStyleBackColor = true;
+            this.buttonAddItem.Click += new System.EventHandler(this.buttonAddItem_Click);
+            // 
+            // buttonRemoveItem
+            // 
+            this.buttonRemoveItem.AutoSize = true;
+            this.buttonRemoveItem.Location = new System.Drawing.Point(72, 3);
+            this.buttonRemoveItem.Name = "buttonRemoveItem";
+            this.buttonRemoveItem.Size = new System.Drawing.Size(81, 23);
+            this.buttonRemoveItem.TabIndex = 1;
+            this.buttonRemoveItem.Text = "Remove Item";
+            this.buttonRemoveItem.UseVisualStyleBackColor = true;
+            this.buttonRemoveItem.Click += new System.EventHandler(this.buttonRemoveItem_Click);
+            // 
+            // Form_DropManager_XML
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(984, 661);
+            this.Controls.Add(this.splitContainerMain);
+            this.Controls.Add(this.menuStrip1);
+            this.MainMenuStrip = this.menuStrip1;
+            this.MinimumSize = new System.Drawing.Size(800, 600);
+            this.Name = "Form_DropManager_XML";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "MU DropManager Editor (XML)";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.Form_DropManager_XML_FormClosed);
+            this.Load += new System.EventHandler(this.Form_DropManager_XML_Load);
+            this.menuStrip1.ResumeLayout(false);
+            this.menuStrip1.PerformLayout();
+            this.splitContainerMain.Panel1.ResumeLayout(false);
+            this.splitContainerMain.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainerMain)).EndInit();
+            this.splitContainerMain.ResumeLayout(false);
+            this.tableLayoutPanelMonsters.ResumeLayout(false);
+            this.tableLayoutPanelMonsters.PerformLayout();
+            this.flowLayoutPanelDropUseRate.ResumeLayout(false);
+            this.flowLayoutPanelDropUseRate.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewMonsters)).EndInit();
+            this.flowLayoutPanelMonsterButtons.ResumeLayout(false);
+            this.flowLayoutPanelMonsterButtons.PerformLayout();
+            this.tableLayoutPanelItems.ResumeLayout(false);
+            this.tableLayoutPanelItems.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewItems)).EndInit();
+            this.flowLayoutPanelItemButtons.ResumeLayout(false);
+            this.flowLayoutPanelItemButtons.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.MenuStrip menuStrip1;
+        private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem newToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem openToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveAsToolStripMenuItem;
+        private System.Windows.Forms.SplitContainer splitContainerMain;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelMonsters;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanelDropUseRate;
+        private System.Windows.Forms.Label labelDropUseRate;
+        private System.Windows.Forms.TextBox textBoxDropUseRate;
+        private System.Windows.Forms.DataGridView dataGridViewMonsters;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanelMonsterButtons;
+        private System.Windows.Forms.Button buttonAddMonster;
+        private System.Windows.Forms.Button buttonRemoveMonster;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelItems;
+        private System.Windows.Forms.DataGridView dataGridViewItems;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanelItemButtons;
+        private System.Windows.Forms.Button buttonAddItem;
+        private System.Windows.Forms.Button buttonRemoveItem;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnMonsterIndex;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnMonsterMinLevel;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnMonsterMaxLevel;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnMonsterMapNumber;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnMonsterItemRate;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnMonsterItemCount;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnMonsterCoinReward;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnMonsterCoinType;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnMonsterCoinValue;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnMonsterPlayerMinLevel;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnMonsterPlayerMaxLevel;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemCat;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemIndex;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemMinLevel;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemMaxLevel;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemDurability;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemSkill;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemLuck;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemOption;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemExc;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemSetItem;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemSocketCount;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemElementalItem;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemMuunCat;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemMuunIndex;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemDropRate;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnItemDuration;
+    }
+}

--- a/MU.ToolKit [Silver Edition]/MU_ToolKit/Form_DropManager_XML.cs
+++ b/MU.ToolKit [Silver Edition]/MU_ToolKit/Form_DropManager_XML.cs
@@ -1,0 +1,193 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Windows.Forms;
+
+namespace MU_ToolKit
+{
+    public partial class Form_DropManager_XML : Form
+    {
+        private readonly BindingSource monsterBindingSource = new BindingSource();
+        private readonly BindingSource itemBindingSource = new BindingSource();
+        private Structures.IGCDropManagerXmlFile currentFile = new Structures.IGCDropManagerXmlFile();
+        private string currentFilePath;
+
+        public Form_DropManager_XML()
+        {
+            InitializeComponent();
+            dataGridViewMonsters.AutoGenerateColumns = false;
+            dataGridViewItems.AutoGenerateColumns = false;
+            monsterBindingSource.CurrentChanged += MonsterBindingSource_CurrentChanged;
+        }
+
+        private void Form_DropManager_XML_Load(object sender, EventArgs e)
+        {
+            BindFile(new Structures.IGCDropManagerXmlFile());
+            Form form = Application.OpenForms["Form1"];
+            if (form != null)
+            {
+                form.WindowState = FormWindowState.Minimized;
+            }
+            WindowState = FormWindowState.Normal;
+            TopMost = true;
+            TopMost = false;
+            BringToFront();
+            Focus();
+        }
+
+        private void Form_DropManager_XML_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            if (Application.OpenForms["Form1"] != null)
+            {
+                Application.OpenForms["Form1"].WindowState = FormWindowState.Normal;
+            }
+        }
+
+        private void BindFile(Structures.IGCDropManagerXmlFile file)
+        {
+            currentFile = file ?? new Structures.IGCDropManagerXmlFile();
+            monsterBindingSource.DataSource = currentFile.Monsters;
+            dataGridViewMonsters.DataSource = monsterBindingSource;
+            textBoxDropUseRate.Text = currentFile.DropUseRate;
+            UpdateItemBinding();
+        }
+
+        private void UpdateItemBinding()
+        {
+            var monster = monsterBindingSource.Current as Structures.IGCDropManagerXmlMonster;
+            if (monster != null)
+            {
+                itemBindingSource.DataSource = monster.Items;
+            }
+            else
+            {
+                itemBindingSource.DataSource = null;
+            }
+
+            dataGridViewItems.DataSource = itemBindingSource;
+        }
+
+        private void MonsterBindingSource_CurrentChanged(object sender, EventArgs e)
+        {
+            UpdateItemBinding();
+        }
+
+        private void dataGridViewMonsters_SelectionChanged(object sender, EventArgs e)
+        {
+            if (monsterBindingSource.Position != dataGridViewMonsters.CurrentCell?.RowIndex && dataGridViewMonsters.CurrentCell != null)
+            {
+                monsterBindingSource.Position = dataGridViewMonsters.CurrentCell.RowIndex;
+            }
+        }
+
+        private void buttonAddMonster_Click(object sender, EventArgs e)
+        {
+            var monster = new Structures.IGCDropManagerXmlMonster();
+            currentFile.Monsters.Add(monster);
+            monsterBindingSource.Position = monsterBindingSource.Count - 1;
+        }
+
+        private void buttonRemoveMonster_Click(object sender, EventArgs e)
+        {
+            if (monsterBindingSource.Current is Structures.IGCDropManagerXmlMonster monster)
+            {
+                currentFile.Monsters.Remove(monster);
+            }
+        }
+
+        private void buttonAddItem_Click(object sender, EventArgs e)
+        {
+            if (monsterBindingSource.Current is Structures.IGCDropManagerXmlMonster monster)
+            {
+                var item = new Structures.IGCDropManagerXmlItem();
+                monster.Items.Add(item);
+                itemBindingSource.Position = itemBindingSource.Count - 1;
+            }
+            else
+            {
+                MessageBox.Show(this, "Selecione uma seção de monstro antes de adicionar itens.", Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+        }
+
+        private void buttonRemoveItem_Click(object sender, EventArgs e)
+        {
+            if (itemBindingSource.Current is Structures.IGCDropManagerXmlItem item && monsterBindingSource.Current is Structures.IGCDropManagerXmlMonster monster)
+            {
+                monster.Items.Remove(item);
+            }
+        }
+
+        private void textBoxDropUseRate_TextChanged(object sender, EventArgs e)
+        {
+            if (currentFile != null)
+            {
+                currentFile.DropUseRate = textBoxDropUseRate.Text.Trim();
+            }
+        }
+
+        private void newToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            currentFilePath = null;
+            BindFile(new Structures.IGCDropManagerXmlFile());
+        }
+
+        private void openToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            using (OpenFileDialog dialog = new OpenFileDialog())
+            {
+                dialog.Filter = "XML Files (*.xml)|*.xml|All Files (*.*)|*.*";
+                if (dialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    try
+                    {
+                        var loadedFile = Structures.LoadIGCDropManagerXml(dialog.FileName);
+                        currentFilePath = dialog.FileName;
+                        BindFile(loadedFile);
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show(this, string.Format("Falha ao carregar o arquivo:\n{0}", ex.Message), Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                }
+            }
+        }
+
+        private void saveToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (string.IsNullOrEmpty(currentFilePath))
+            {
+                saveAsToolStripMenuItem_Click(sender, e);
+                return;
+            }
+
+            SaveToPath(currentFilePath);
+        }
+
+        private void saveAsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            using (SaveFileDialog dialog = new SaveFileDialog())
+            {
+                dialog.Filter = "XML Files (*.xml)|*.xml|All Files (*.*)|*.*";
+                dialog.FileName = string.IsNullOrEmpty(currentFilePath) ? "IGC_DropManager.xml" : Path.GetFileName(currentFilePath);
+                if (dialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    currentFilePath = dialog.FileName;
+                    SaveToPath(currentFilePath);
+                }
+            }
+        }
+
+        private void SaveToPath(string path)
+        {
+            try
+            {
+                currentFile.DropUseRate = textBoxDropUseRate.Text.Trim();
+                Structures.SaveIGCDropManagerXml(currentFile, path);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, string.Format("Falha ao salvar o arquivo:\n{0}", ex.Message), Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+    }
+}

--- a/MU.ToolKit [Silver Edition]/MU_ToolKit/Form_DropManager_XML.resx
+++ b/MU.ToolKit [Silver Edition]/MU_ToolKit/Form_DropManager_XML.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/MU.ToolKit [Silver Edition]/MU_ToolKit/Structures.cs
+++ b/MU.ToolKit [Silver Edition]/MU_ToolKit/Structures.cs
@@ -2003,7 +2003,255 @@ namespace MU_ToolKit
 		}
 
 		// Token: 0x0200001C RID: 28
-		public struct IGCDropManagerFile
+                public class IGCDropManagerXmlItem
+                {
+                        public IGCDropManagerXmlItem()
+                        {
+                                this.Cat = "0";
+                                this.Index = "0";
+                                this.ItemMinLevel = "0";
+                                this.ItemMaxLevel = "0";
+                                this.Durability = "-1";
+                                this.Skill = "0";
+                                this.Luck = "0";
+                                this.Option = "0";
+                                this.Exc = "0";
+                                this.SetItem = "0";
+                                this.SocketCount = "0";
+                                this.ElementalItem = "0";
+                                this.MuunEvolutionItemCat = "0";
+                                this.MuunEvolutionItemIndex = "0";
+                                this.DropRate = "1";
+                                this.Duration = "0";
+                        }
+
+                        public string Cat { get; set; }
+
+                        public string Index { get; set; }
+
+                        public string ItemMinLevel { get; set; }
+
+                        public string ItemMaxLevel { get; set; }
+
+                        public string Durability { get; set; }
+
+                        public string Skill { get; set; }
+
+                        public string Luck { get; set; }
+
+                        public string Option { get; set; }
+
+                        public string Exc { get; set; }
+
+                        public string SetItem { get; set; }
+
+                        public string SocketCount { get; set; }
+
+                        public string ElementalItem { get; set; }
+
+                        public string MuunEvolutionItemCat { get; set; }
+
+                        public string MuunEvolutionItemIndex { get; set; }
+
+                        public string DropRate { get; set; }
+
+                        public string Duration { get; set; }
+
+                        public override string ToString()
+                        {
+                                return string.Format("Cat={0} Index={1} DropRate={2}", this.Cat, this.Index, this.DropRate);
+                        }
+                }
+
+                public class IGCDropManagerXmlMonster
+                {
+                        public IGCDropManagerXmlMonster()
+                        {
+                                this.Index = "-1";
+                                this.MonsterMinLevel = "1";
+                                this.MonsterMaxLevel = "150";
+                                this.MapNumber = "-1";
+                                this.ItemRate = "10000";
+                                this.ItemCount = "1";
+                                this.CoinReward = "0";
+                                this.CoinType = "0";
+                                this.CoinValue = "0";
+                                this.PlayerMinLevel = "1";
+                                this.PlayerMaxLevel = "MAX";
+                                this.Items = new BindingList<Structures.IGCDropManagerXmlItem>();
+                        }
+
+                        public string Index { get; set; }
+
+                        public string MonsterMinLevel { get; set; }
+
+                        public string MonsterMaxLevel { get; set; }
+
+                        public string MapNumber { get; set; }
+
+                        public string ItemRate { get; set; }
+
+                        public string ItemCount { get; set; }
+
+                        public string CoinReward { get; set; }
+
+                        public string CoinType { get; set; }
+
+                        public string CoinValue { get; set; }
+
+                        public string PlayerMinLevel { get; set; }
+
+                        public string PlayerMaxLevel { get; set; }
+
+                        public BindingList<Structures.IGCDropManagerXmlItem> Items { get; private set; }
+
+                        public override string ToString()
+                        {
+                                return string.Format("Index={0} Map={1} Rate={2}", this.Index, this.MapNumber, this.ItemRate);
+                        }
+                }
+
+                public class IGCDropManagerXmlFile
+                {
+                        public IGCDropManagerXmlFile()
+                        {
+                                this.DropUseRate = "1000000";
+                                this.Monsters = new BindingList<Structures.IGCDropManagerXmlMonster>();
+                        }
+
+                        public string DropUseRate { get; set; }
+
+                        public BindingList<Structures.IGCDropManagerXmlMonster> Monsters { get; private set; }
+                }
+
+                public static Structures.IGCDropManagerXmlFile LoadIGCDropManagerXml(string fileName)
+                {
+                        if (string.IsNullOrWhiteSpace(fileName))
+                        {
+                                throw new ArgumentException("Arquivo inválido", "fileName");
+                        }
+                        XDocument xdocument = XDocument.Load(fileName);
+                        XElement xelement = xdocument.Element("DropManager");
+                        if (xelement == null)
+                        {
+                                throw new InvalidDataException("O nó DropManager não foi encontrado.");
+                        }
+                        Structures.IGCDropManagerXmlFile igcdropManagerXmlFile = new Structures.IGCDropManagerXmlFile();
+                        igcdropManagerXmlFile.DropUseRate = Structures.GetAttributeValue(xelement, "DropUseRate", igcdropManagerXmlFile.DropUseRate);
+                        foreach (XElement xelement2 in xelement.Elements("Monster"))
+                        {
+                                Structures.IGCDropManagerXmlMonster igcdropManagerXmlMonster = new Structures.IGCDropManagerXmlMonster();
+                                igcdropManagerXmlMonster.Index = Structures.GetAttributeValue(xelement2, "Index", igcdropManagerXmlMonster.Index);
+                                igcdropManagerXmlMonster.MonsterMinLevel = Structures.GetAttributeValue(xelement2, "MonsterMinLevel", igcdropManagerXmlMonster.MonsterMinLevel);
+                                igcdropManagerXmlMonster.MonsterMaxLevel = Structures.GetAttributeValue(xelement2, "MonsterMaxLevel", igcdropManagerXmlMonster.MonsterMaxLevel);
+                                igcdropManagerXmlMonster.MapNumber = Structures.GetAttributeValue(xelement2, "MapNumber", igcdropManagerXmlMonster.MapNumber);
+                                igcdropManagerXmlMonster.ItemRate = Structures.GetAttributeValue(xelement2, "ItemRate", igcdropManagerXmlMonster.ItemRate);
+                                igcdropManagerXmlMonster.ItemCount = Structures.GetAttributeValue(xelement2, "ItemCount", igcdropManagerXmlMonster.ItemCount);
+                                igcdropManagerXmlMonster.CoinReward = Structures.GetAttributeValue(xelement2, "CoinReward", igcdropManagerXmlMonster.CoinReward);
+                                igcdropManagerXmlMonster.CoinType = Structures.GetAttributeValue(xelement2, "CoinType", igcdropManagerXmlMonster.CoinType);
+                                igcdropManagerXmlMonster.CoinValue = Structures.GetAttributeValue(xelement2, "CoinValue", igcdropManagerXmlMonster.CoinValue);
+                                igcdropManagerXmlMonster.PlayerMinLevel = Structures.GetAttributeValue(xelement2, "PlayerMinLevel", igcdropManagerXmlMonster.PlayerMinLevel);
+                                igcdropManagerXmlMonster.PlayerMaxLevel = Structures.GetAttributeValue(xelement2, "PlayerMaxLevel", igcdropManagerXmlMonster.PlayerMaxLevel);
+                                foreach (XElement xelement3 in xelement2.Elements("Item"))
+                                {
+                                        Structures.IGCDropManagerXmlItem igcdropManagerXmlItem = new Structures.IGCDropManagerXmlItem();
+                                        igcdropManagerXmlItem.Cat = Structures.GetAttributeValue(xelement3, "Cat", igcdropManagerXmlItem.Cat);
+                                        igcdropManagerXmlItem.Index = Structures.GetAttributeValue(xelement3, "Index", igcdropManagerXmlItem.Index);
+                                        igcdropManagerXmlItem.ItemMinLevel = Structures.GetAttributeValue(xelement3, "ItemMinLevel", igcdropManagerXmlItem.ItemMinLevel);
+                                        igcdropManagerXmlItem.ItemMaxLevel = Structures.GetAttributeValue(xelement3, "ItemMaxLevel", igcdropManagerXmlItem.ItemMaxLevel);
+                                        igcdropManagerXmlItem.Durability = Structures.GetAttributeValue(xelement3, "Durability", igcdropManagerXmlItem.Durability);
+                                        igcdropManagerXmlItem.Skill = Structures.GetAttributeValue(xelement3, "Skill", igcdropManagerXmlItem.Skill);
+                                        igcdropManagerXmlItem.Luck = Structures.GetAttributeValue(xelement3, "Luck", igcdropManagerXmlItem.Luck);
+                                        igcdropManagerXmlItem.Option = Structures.GetAttributeValue(xelement3, "Option", igcdropManagerXmlItem.Option);
+                                        igcdropManagerXmlItem.Exc = Structures.GetAttributeValue(xelement3, "Exc", igcdropManagerXmlItem.Exc);
+                                        igcdropManagerXmlItem.SetItem = Structures.GetAttributeValue(xelement3, "SetItem", igcdropManagerXmlItem.SetItem);
+                                        igcdropManagerXmlItem.SocketCount = Structures.GetAttributeValue(xelement3, "SocketCount", igcdropManagerXmlItem.SocketCount);
+                                        igcdropManagerXmlItem.ElementalItem = Structures.GetAttributeValue(xelement3, "ElementalItem", igcdropManagerXmlItem.ElementalItem);
+                                        igcdropManagerXmlItem.MuunEvolutionItemCat = Structures.GetAttributeValue(xelement3, "MuunEvolutionItemCat", igcdropManagerXmlItem.MuunEvolutionItemCat);
+                                        igcdropManagerXmlItem.MuunEvolutionItemIndex = Structures.GetAttributeValue(xelement3, "MuunEvolutionItemIndex", igcdropManagerXmlItem.MuunEvolutionItemIndex);
+                                        igcdropManagerXmlItem.DropRate = Structures.GetAttributeValue(xelement3, "DropRate", igcdropManagerXmlItem.DropRate);
+                                        igcdropManagerXmlItem.Duration = Structures.GetAttributeValue(xelement3, "Duration", igcdropManagerXmlItem.Duration);
+                                        igcdropManagerXmlMonster.Items.Add(igcdropManagerXmlItem);
+                                }
+                                igcdropManagerXmlFile.Monsters.Add(igcdropManagerXmlMonster);
+                        }
+                        return igcdropManagerXmlFile;
+                }
+
+                public static void SaveIGCDropManagerXml(Structures.IGCDropManagerXmlFile file, string fileName)
+                {
+                        if (file == null)
+                        {
+                                throw new ArgumentNullException("file");
+                        }
+                        if (string.IsNullOrWhiteSpace(fileName))
+                        {
+                                throw new ArgumentException("Arquivo inválido", "fileName");
+                        }
+                        XElement xelement = new XElement("DropManager");
+                        xelement.SetAttributeValue("DropUseRate", Structures.NormalizeAttribute(file.DropUseRate, "1000000"));
+                        foreach (Structures.IGCDropManagerXmlMonster igcdropManagerXmlMonster in file.Monsters)
+                        {
+                                XElement xelement2 = new XElement("Monster");
+                                Structures.SetAttributeValue(xelement2, "Index", igcdropManagerXmlMonster.Index, "-1");
+                                Structures.SetAttributeValue(xelement2, "MonsterMinLevel", igcdropManagerXmlMonster.MonsterMinLevel, "-1");
+                                Structures.SetAttributeValue(xelement2, "MonsterMaxLevel", igcdropManagerXmlMonster.MonsterMaxLevel, "-1");
+                                Structures.SetAttributeValue(xelement2, "MapNumber", igcdropManagerXmlMonster.MapNumber, "-1");
+                                Structures.SetAttributeValue(xelement2, "ItemRate", igcdropManagerXmlMonster.ItemRate, "0");
+                                Structures.SetAttributeValue(xelement2, "ItemCount", igcdropManagerXmlMonster.ItemCount, "0");
+                                Structures.SetAttributeValue(xelement2, "CoinReward", igcdropManagerXmlMonster.CoinReward, "0");
+                                Structures.SetAttributeValue(xelement2, "CoinType", igcdropManagerXmlMonster.CoinType, "0");
+                                Structures.SetAttributeValue(xelement2, "CoinValue", igcdropManagerXmlMonster.CoinValue, "0");
+                                Structures.SetAttributeValue(xelement2, "PlayerMinLevel", igcdropManagerXmlMonster.PlayerMinLevel, "0");
+                                Structures.SetAttributeValue(xelement2, "PlayerMaxLevel", igcdropManagerXmlMonster.PlayerMaxLevel, "MAX");
+                                foreach (Structures.IGCDropManagerXmlItem igcdropManagerXmlItem in igcdropManagerXmlMonster.Items)
+                                {
+                                        XElement xelement3 = new XElement("Item");
+                                        Structures.SetAttributeValue(xelement3, "Cat", igcdropManagerXmlItem.Cat, "0");
+                                        Structures.SetAttributeValue(xelement3, "Index", igcdropManagerXmlItem.Index, "0");
+                                        Structures.SetAttributeValue(xelement3, "ItemMinLevel", igcdropManagerXmlItem.ItemMinLevel, "0");
+                                        Structures.SetAttributeValue(xelement3, "ItemMaxLevel", igcdropManagerXmlItem.ItemMaxLevel, "0");
+                                        Structures.SetAttributeValue(xelement3, "Durability", igcdropManagerXmlItem.Durability, "-1");
+                                        Structures.SetAttributeValue(xelement3, "Skill", igcdropManagerXmlItem.Skill, "0");
+                                        Structures.SetAttributeValue(xelement3, "Luck", igcdropManagerXmlItem.Luck, "0");
+                                        Structures.SetAttributeValue(xelement3, "Option", igcdropManagerXmlItem.Option, "0");
+                                        Structures.SetAttributeValue(xelement3, "Exc", igcdropManagerXmlItem.Exc, "0");
+                                        Structures.SetAttributeValue(xelement3, "SetItem", igcdropManagerXmlItem.SetItem, "0");
+                                        Structures.SetAttributeValue(xelement3, "SocketCount", igcdropManagerXmlItem.SocketCount, "0");
+                                        Structures.SetAttributeValue(xelement3, "ElementalItem", igcdropManagerXmlItem.ElementalItem, "0");
+                                        Structures.SetAttributeValue(xelement3, "MuunEvolutionItemCat", igcdropManagerXmlItem.MuunEvolutionItemCat, "0");
+                                        Structures.SetAttributeValue(xelement3, "MuunEvolutionItemIndex", igcdropManagerXmlItem.MuunEvolutionItemIndex, "0");
+                                        Structures.SetAttributeValue(xelement3, "DropRate", igcdropManagerXmlItem.DropRate, "0");
+                                        Structures.SetAttributeValue(xelement3, "Duration", igcdropManagerXmlItem.Duration, "0");
+                                        xelement2.Add(xelement3);
+                                }
+                                xelement.Add(xelement2);
+                        }
+                        XDocument xdocument = new XDocument(new XDeclaration("1.0", "utf-8", "yes"), xelement);
+                        xdocument.Save(fileName);
+                }
+
+                private static string GetAttributeValue(XElement element, string attributeName, string defaultValue)
+                {
+                        XAttribute xattribute = element.Attribute(attributeName);
+                        if (xattribute == null || string.IsNullOrWhiteSpace(xattribute.Value))
+                        {
+                                return defaultValue;
+                        }
+                        return xattribute.Value.Trim();
+                }
+
+                private static string NormalizeAttribute(string value, string defaultValue)
+                {
+                        return string.IsNullOrWhiteSpace(value) ? defaultValue : value.Trim();
+                }
+
+                private static void SetAttributeValue(XElement element, string attributeName, string value, string defaultValue)
+                {
+                        element.SetAttributeValue(attributeName, Structures.NormalizeAttribute(value, defaultValue));
+                }
+
+                public struct IGCDropManagerFile
 		{
 			// Token: 0x17000369 RID: 873
 			// (get) Token: 0x060003E1 RID: 993 RVA: 0x0001A73A File Offset: 0x0001893A


### PR DESCRIPTION
## Summary
- add DropManager XML models and load/save helpers to map all attributes from IGC_DropManager.xml
- create a dedicated MU DropManager XML editor form with monster and item grids plus DropUseRate support
- update the Server Tools menu to launch either the legacy DAT editor or the new XML editor

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68c9e69dd4dc8332b0acc4577a619f90